### PR TITLE
fix(api): Improve init() signature and callback error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,8 +318,11 @@ events.docReady(() => {
     // Handle all dynamic module imports
     loadModules({
         'assets': 'https://cdn.example.com/js/' // Optional: path aliases
-    }, () => {
-        console.log('All modules initialized');
+    }, (results) => {
+        console.log(`${results.loaded.length} modules initialized`);
+        if (results.failed.length > 0) {
+            console.warn('Failed modules:', results.failed.map(f => f.path));
+        }
     });
 });
 ```
@@ -377,10 +380,16 @@ export const NAME = 'fadeInModule';
 
 /**
  * Called automatically when module is loaded
- * @param {NodeList} elements - All elements with data-requires="./example-module.mjs"
+ * @param {HTMLElement[]} elements - All elements with data-requires="./example-module.mjs"
+ * @param {Object|null} context - null for immediate loads, or {isLazy, triggeringElement} for lazy loads
  * @returns {string|boolean|undefined} Optional status message
  */
-export function init(elements) {
+export function init(elements, context) {
+    // For lazy-loaded modules, context contains the triggering element
+    if (context?.isLazy) {
+        logger.log(NAME, `Lazy loaded by: ${context.triggeringElement.tagName}`);
+    }
+
     // Check visibility on scroll/resize
     events.addListener('docShift', () => {
         elements.forEach(element => {
@@ -408,7 +417,13 @@ import {logger} from "./core.log.mjs";
 
 export const NAME = 'exampleModule';
 
-export function init(elements) {
+/**
+ * @param {HTMLElement[]} elements - All elements requiring this module
+ * @param {Object|null} context - Lazy load context (null for immediate loads)
+ * @param {boolean} context.isLazy - True if lazy-loaded
+ * @param {HTMLElement} context.triggeringElement - Element that triggered lazy load
+ */
+export function init(elements, context) {
     // Your code here
 
     // Optional: listen for events

--- a/core.loader.mjs
+++ b/core.loader.mjs
@@ -418,13 +418,15 @@ function importModule(key, elements, dynImportPaths, isLazy = false, triggeringE
             if (typeof module.init === 'function') {
                 logger.info(name, `Initializing${loadType} for ${elements.length} element(s).`);
 
-                // Attach lazy context if needed
-                if (isLazy) {
-                    elements.triggeringElement = triggeringElement;
-                }
+                // Build context object for init() - passed as second parameter
+                // Context is null for immediate loads, contains metadata for lazy loads
+                const context = isLazy ? {
+                    isLazy: true,
+                    triggeringElement: triggeringElement
+                } : null;
 
                 try {
-                    const result = module.init.call(module, elements);
+                    const result = module.init.call(module, elements, context);
                     ModuleRegistry.register(name, module, elements, 'loaded');
 
                     if (result === false) {
@@ -435,11 +437,6 @@ function importModule(key, elements, dynImportPaths, isLazy = false, triggeringE
                 } catch (error) {
                     ModuleRegistry.register(name, module, elements, 'error');
                     logger.error(name, `Initialization failed: ${error.message}`);
-                } finally {
-                    // Clean up lazy context
-                    if (isLazy) {
-                        delete elements.triggeringElement;
-                    }
                 }
             }
 
@@ -753,15 +750,24 @@ function setupScrollWatcher(key, elements, dynImportPaths, checkObstructions = f
  *
  * Immediate modules load in parallel. Lazy modules (data-require-lazy="true")
  * load when their elements become visible. All module init() functions receive
- * arrays of all elements that required them.
+ * arrays of all elements that required them, plus an optional context object.
+ *
+ * Module init() signature:
+ *   init(elements, context)
+ *   - elements: HTMLElement[] - All elements that required this module
+ *   - context: Object|null - null for immediate loads, {isLazy, triggeringElement} for lazy loads
  *
  * @param {Object<string, string>|Function} [paths] - Path alias mappings or callback
- * @param {Function} [callback] - Called after all immediate modules finish loading
+ * @param {Function} [callback] - Called after all immediate modules finish loading.
+ *   Receives results object: {loaded: Array<{path, module}>, failed: Array<{path, error}>}
  *
  * @example
  * // Basic usage
- * loadModules(() => {
- *   console.log('All modules loaded');
+ * loadModules((results) => {
+ *   console.log(`${results.loaded.length} modules loaded`);
+ *   if (results.failed.length > 0) {
+ *     console.warn('Some modules failed:', results.failed);
+ *   }
  * });
  *
  * @example
@@ -769,8 +775,8 @@ function setupScrollWatcher(key, elements, dynImportPaths, checkObstructions = f
  * loadModules({
  *   'assets': 'https://cdn.example.com/js/',
  *   'vendor': 'https://unpkg.com/'
- * }, () => {
- *   console.log('Modules loaded');
+ * }, (results) => {
+ *   console.log('Modules loaded:', results.loaded.map(r => r.path));
  * });
  */
 export function loadModules(paths, callback) {
@@ -791,11 +797,27 @@ export function loadModules(paths, callback) {
             );
         }
 
-        Promise.allSettled(importPromises).then(function() {
-            logger.info(NAME, 'All dynamic imports finished loading.');
+        Promise.allSettled(importPromises).then(function(results) {
+            // Build results summary for callback
+            const moduleKeys = Object.keys(modules);
+            const loaded = [];
+            const failed = [];
+
+            results.forEach((result, index) => {
+                const path = moduleKeys[index];
+                if (result.status === 'fulfilled') {
+                    loaded.push({ path, module: result.value });
+                } else {
+                    failed.push({ path, error: result.reason });
+                }
+            });
+
+            logger.info(NAME, `All dynamic imports finished. ${loaded.length} loaded, ${failed.length} failed.`);
             logger.info(NAME, { modules: modules, deferredModules: deferred });
+
             if (typeof callback === 'function') {
-                callback.call(this);
+                // Pass results object with loaded/failed arrays for programmatic error handling
+                callback.call(this, { loaded, failed });
             }
         });
 
@@ -853,8 +875,17 @@ export function dynImports(...args) {
  * Cleanup function to remove all listeners and observers.
  * Call before unmounting in SPAs to prevent memory leaks.
  *
+ * This is the cancellation mechanism for pending lazy loads:
+ * - Disconnects all IntersectionObservers and MutationObservers
+ * - Removes all scroll event listeners (fallback lazy loading)
+ * - Clears pending deferred modules and loading state
+ * - Resets path cache for potential reuse
+ *
+ * For per-module cleanup, modules should implement their own destroy() function
+ * and call ModuleRegistry.unregister(NAME) when done.
+ *
  * @example
- * // In SPA route change
+ * // In SPA route change - cancel all pending lazy loads
  * import {cleanup} from './core.loader.mjs';
  * cleanup();
  */

--- a/core.registry.mjs
+++ b/core.registry.mjs
@@ -22,6 +22,23 @@
  * - Pending: Map of promises awaiting module loads
  * - Validation: Enforces api() interface for coordination
  *
+ * Design Intent - Choosing the right method:
+ *
+ *   waitFor(name) - Use when you need to COORDINATE with another module.
+ *     Requires api() because coordination implies calling the other module's interface.
+ *     Returns a promise that resolves when the module is ready for coordination.
+ *
+ *   isLoaded(name) - Use for synchronous checks ("is this module present?").
+ *     Does NOT require api(). Use when you just need to know if something loaded.
+ *
+ *   get(name) - Use to access module exports directly.
+ *     Does NOT require api(). Returns raw module object for direct access.
+ *     Caller is responsible for checking if the interface they need exists.
+ *
+ * The api() requirement on waitFor() is intentional: if you're waiting for a module,
+ * you presumably need to interact with it. Modules without api() don't support
+ * inter-module coordination - use isLoaded()/get() for those instead.
+ *
  * @example
  * // In a module that provides coordination
  * export const NAME = 'gallery';
@@ -112,15 +129,22 @@ export const ModuleRegistry = {
     },
 
     /**
-     * Check if module is loaded successfully.
-     * Does not verify api() interface - use get() or waitFor() for that.
+     * Check if module is loaded successfully (synchronous).
+     * Does not verify api() interface - returns true for any loaded module.
+     *
+     * Use this when:
+     * - You need a synchronous check (no waiting)
+     * - You don't need to call the module's api()
+     * - You just want to know if something is present
+     *
+     * For async waiting with api() validation, use waitFor() instead.
      *
      * @param {string} name - Module name
      * @returns {boolean} True if module loaded successfully
      *
      * @example
      * if (ModuleRegistry.isLoaded('gallery')) {
-     *   // Gallery is available
+     *   // Gallery is available - can use get() to access it
      * }
      */
     isLoaded(name) {
@@ -129,12 +153,18 @@ export const ModuleRegistry = {
     },
 
     /**
-     * Get module exports (or null if not loaded).
+     * Get module exports directly (synchronous).
      * Returns raw module object - does not validate api() interface.
-     * For coordinated access with validation, use waitFor().
+     *
+     * Use this when:
+     * - You need synchronous access (module should already be loaded)
+     * - You want to access exports other than api()
+     * - You'll handle api() validation yourself
+     *
+     * For async waiting with api() validation, use waitFor() instead.
      *
      * @param {string} name - Module name
-     * @returns {Object|null} Module exports or null
+     * @returns {Object|null} Module exports or null if not loaded
      *
      * @example
      * const gallery = ModuleRegistry.get('gallery');
@@ -164,8 +194,18 @@ export const ModuleRegistry = {
 
     /**
      * Wait for module to load and verify it has api() interface.
-     * Returns promise that resolves when module is ready for coordination.
-     * Rejects if module doesn't load, has errors, or lacks api() function.
+     * Returns promise that resolves when module is ready for inter-module coordination.
+     *
+     * DESIGN NOTE: The api() requirement is intentional. This method is specifically
+     * for inter-module coordination - you're waiting because you need to call the
+     * other module's api(). If you don't need coordination:
+     *   - Use isLoaded() for synchronous presence checks
+     *   - Use get() for direct module access without api() requirement
+     *
+     * Rejects if:
+     *   - Module doesn't load within timeout
+     *   - Module loads but has no api() function (not designed for coordination)
+     *   - Module init() threw an error
      *
      * @param {string} name - Module name to wait for
      * @param {number} [timeout=30000] - Maximum wait time in milliseconds

--- a/modules/_template.mjs
+++ b/modules/_template.mjs
@@ -79,11 +79,21 @@ let changeListeners = [];
  * init
  * Exported function that is called (if present) when the module has been imported via the data-requires method,
  * as described in, and handled by, the core.loader module.
+ *
  * @param {HTMLElement[]} els - Holds *all* DOM elements that had 'data-requires' specified for this module
+ * @param {Object|null} context - Context object for lazy-loaded modules, null for immediate loads
+ * @param {boolean} context.isLazy - True if module was lazy-loaded
+ * @param {HTMLElement} context.triggeringElement - The element that triggered the lazy load
+ *
  * 'this' will be the module object context
  */
-export function init(els) {
+export function init(els, context) {
     elements = els;
+
+    // For lazy-loaded modules, you can access the triggering element
+    if (context?.isLazy) {
+        logger.info(NAME, `Lazy loaded, triggered by: ${context.triggeringElement.tagName}`);
+    }
 
     /**
      * Do stuff here. You can safely assume the page is ready now, as the importing of dynamically loaded modules depends


### PR DESCRIPTION
Addresses remaining API design issues from issue #7:

Problem 4 - Context passing:
- Changed init() to receive context as second parameter instead of mutating the elements array
- init(elements, context) where context is null for immediate loads or {isLazy, triggeringElement} for lazy loads
- Eliminates awkward array property mutation pattern

Problem 5 - Silent failures:
- loadModules() callback now receives results object: {loaded: [{path, module}], failed: [{path, error}]}
- Enables programmatic error handling for partial failures

Also adds clarifying comments to prevent misidentification of intentional design decisions:
- core.registry.mjs: Explains why waitFor() requires api() and when to use isLoaded()/get() instead
- core.loader.mjs: Clarifies cleanup() as the cancellation mechanism

Documentation updated:
- README.md: Updated examples with new signatures
- modules/_template.mjs: Added context parameter documentation