### PR TITLE
docs: Add testing documentation and production distribution config (v3.2.0)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# ============================================================================
+# EXPORT IGNORE - Excluded from `git archive` (production builds)
+# ============================================================================
+
+# Test files
+__tests__/                  export-ignore
+vitest.config.mjs           export-ignore
+coverage/                   export-ignore
+
+# Development configuration
+.github/                    export-ignore
+.gitattributes              export-ignore
+
+# Package management (not needed in production)
+package.json                export-ignore
+package-lock.json           export-ignore
+node_modules/               export-ignore
+
+# Documentation that's not needed in production
+CHANGELOG.md                export-ignore
+CONTRIBUTING.md             export-ignore

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A lightweight module loader that lets DOM elements request their own JavaScript 
 - [Using Third-Party Modules](#using-third-party-modules)
 - [Migration Guide (v2.x → v3.0)](#migration-guide-v2x--v30)
 - [Troubleshooting](#troubleshooting)
+- [Testing](#testing)
 - [DOM... what?](#so-why-is-it-called-domule)
 - [Notes](#notes)
 
@@ -1167,6 +1168,69 @@ Core features require ES6 module support. Optional features degrade gracefully:
 - Minimize number of small modules (bundle related functionality)
 - Disable debug mode in production
 - Use browser cache
+
+---
+
+## Testing
+
+DOMule includes a comprehensive test suite using [Vitest](https://vitest.dev/).
+
+### Running Tests
+
+```bash
+# Install dependencies (first time only)
+npm install
+
+# Run all tests
+npm test
+
+# Watch mode (re-runs on file changes)
+npm run test:watch
+
+# With coverage report
+npm run test:coverage
+```
+
+### Test Structure
+
+```
+__tests__/
+├── core.*.test.mjs       # Core module tests (loader, registry, events, etc.)
+├── util.*.test.mjs       # Utility function tests (debounce, observe, format, etc.)
+├── integration.test.mjs  # Full loading flow tests
+└── module.compat.test.mjs # Module compatibility checker
+```
+
+### Testing Your Custom Modules
+
+Validate that your module is compatible with DOMule:
+
+```bash
+# Linux/Mac
+MODULE=./modules/mymodule.mjs npm run test:module
+
+# Windows CMD
+set MODULE=./modules/mymodule.mjs && npm run test:module
+
+# PowerShell
+$env:MODULE="./modules/mymodule.mjs"; npm run test:module
+```
+
+This checks for:
+- Required `NAME` export
+- Valid `init(elements, context)` signature
+- Optional `api()` and `destroy()` functions
+- ModuleRegistry compatibility
+
+### Production Checkout (without tests)
+
+Use `git archive` to export DOMule without test files and development dependencies:
+
+```bash
+git archive --format=zip HEAD -o domule-production.zip
+```
+
+The `.gitattributes` file excludes `__tests__/`, `node_modules/`, `package.json`, and other development files from the archive.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1222,15 +1222,22 @@ This checks for:
 - Optional `api()` and `destroy()` functions
 - ModuleRegistry compatibility
 
-### Production Checkout (without tests)
+### Production Distribution (without tests)
 
-Use `git archive` to export DOMule without test files and development dependencies:
+Two options for getting a clean distribution without test files:
 
+**Option 1: npm pack**
+```bash
+npm pack
+# Creates domule-3.2.0.tgz with only production files
+```
+
+**Option 2: git archive**
 ```bash
 git archive --format=zip HEAD -o domule-production.zip
 ```
 
-The `.gitattributes` file excludes `__tests__/`, `node_modules/`, `package.json`, and other development files from the archive.
+Both methods exclude `__tests__/`, `node_modules/`, and other development files. The `files` field in `package.json` controls npm pack output, while `.gitattributes` controls git archive.
 
 ---
 
@@ -1251,6 +1258,6 @@ DOM + Module + Mule.
 This is a personal repository for maintaining the module system. Feel free to use it, but note: modules may change
 without prior notice.
 
-**Version:** 3.1.0  
+**Version:** 3.2.0  
 **License:** MIT  
 **Author:** Klaas Leussink / hnldesign

--- a/package.json
+++ b/package.json
@@ -1,8 +1,22 @@
 {
   "name": "domule",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A lightweight module loader that lets DOM elements request their own JavaScript dependencies",
   "type": "module",
+  "main": "DOMule.mjs",
+  "files": [
+    "core.*.mjs",
+    "util.*.mjs",
+    "modules/",
+    "DOMule.mjs",
+    "_template.mjs",
+    "README.md",
+    "LICENSE"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/c-kick/DOMule.git"
+  },
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary

- Add comprehensive Testing section to README documenting test commands, structure, and custom module validation
- Add `.gitattributes` with `export-ignore` rules for clean `git archive` exports
- Add `files` field to `package.json` for clean `npm pack` distribution
- Bump version to 3.2.0

## Changes

### README.md
- New "Testing" section with instructions for running tests, test structure overview, and custom module validation
- "Production Distribution" section documenting both `npm pack` and `git archive` approaches

### package.json
- Added `main` entry point (`DOMule.mjs`)
- Added `files` array specifying production files for npm
- Added `repository` field
- Version bump: 3.1.0 → 3.2.0

### .gitattributes (new)
- Excludes `__tests__/`, `node_modules/`, CI config, and dev files from `git archive`